### PR TITLE
Adding compatibility with new apktool version 2.0.0

### DIFF
--- a/inject.sh
+++ b/inject.sh
@@ -1,12 +1,28 @@
 #!/bin/sh
 
+apktool=$(which apktool)
+version=$($apktool --version)
+original_apk=$1
+
+function detect_version()
+{
+if [ "$version" \> "1.5.2" ]
+then
+    echo "-o"       # new output folder syntax for version 2.0.0-RC2
+else
+    echo ""
+fi
+}
+
+output_parameter=$(detect_version)
+
 # prepare the directory structure
 rm -rf patch
 mkdir -p patch
 
 # disassemble original apk and injected apk
-apktool d bin/injector.apk patch/injector
-apktool d $1 patch/orig
+$apktool d bin/injector.apk $output_parameter patch/injector
+$apktool d $original_apk $output_parameter patch/orig
 
 # injecting introspection classes
 cp -r patch/injector/smali/* patch/orig/smali/
@@ -18,7 +34,7 @@ sed -i -e 's/<\/application>/<service android:name="com.sysdream.fino.Inspection
 sed -i -e 's/<uses-sdk[^>]+>/<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="15" \/>/' patch/orig/AndroidManifest.xml
 
 # build the unsigned apk
-apktool b patch/orig tmp.apk
+apktool b patch/orig $output_parameter tmp.apk
 
 # sign the final apk
 jarsigner -verbose -sigalg MD5withRSA -digestalg SHA1 -keystore ~/.android/debug.keystore -storepass android -signedjar $2 tmp.apk androiddebugkey


### PR DESCRIPTION
apktool version 2.0.0-RC2 added a output folder parameter "-o".
apktool's previous version (1.5.2) still works fine with the tool.
